### PR TITLE
fix: update dependancies

### DIFF
--- a/packages/backstage-plugin-autogov-releases-card/package.json
+++ b/packages/backstage-plugin-autogov-releases-card/package.json
@@ -41,7 +41,7 @@
     "@backstage/plugin-catalog-react": "^1.14.0",
     "@backstage/theme": "^0.5.7",
     "@material-ui/core": "^4.9.13",
-    "@material-ui/icons": "^4.9.1",
+    "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.61",
     "react-use": "^17.2.4",
     "styled-components": "^6.1.13"

--- a/packages/backstage-plugin-autogov-status-catalog-column/package.json
+++ b/packages/backstage-plugin-autogov-status-catalog-column/package.json
@@ -41,7 +41,7 @@
     "@backstage/plugin-catalog-react": "^1.14.0",
     "@backstage/theme": "^0.5.7",
     "@liatrio/backstage-plugin-backend-module-autogov-processor": "^1.3.2",
-    "@material-ui/core": "^4.9.13",
+    "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.61",
     "react-use": "^17.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5312,7 +5312,7 @@ __metadata:
     "@backstage/test-utils": "npm:^1.6.0"
     "@backstage/theme": "npm:^0.5.7"
     "@material-ui/core": "npm:^4.9.13"
-    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/icons": "npm:^4.11.3"
     "@material-ui/lab": "npm:^4.0.0-alpha.61"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
@@ -5346,7 +5346,7 @@ __metadata:
     "@backstage/test-utils": "npm:^1.6.0"
     "@backstage/theme": "npm:^0.5.7"
     "@liatrio/backstage-plugin-backend-module-autogov-processor": "npm:^1.3.2"
-    "@material-ui/core": "npm:^4.9.13"
+    "@material-ui/core": "npm:^4.12.4"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:^4.0.0-alpha.61"
     "@testing-library/dom": "npm:^10.4.0"
@@ -5501,7 +5501,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@material-ui/icons@npm:^4.9.1":
+"@material-ui/icons@npm:^4.11.3, @material-ui/icons@npm:^4.9.1":
   version: 4.11.3
   resolution: "@material-ui/icons@npm:4.11.3"
   dependencies:


### PR DESCRIPTION
---
name: Update dependancies for material elements to support linting and testing
description: 
---

## Description

Update the dependancies for material elements in the `packages/backstage-plugin-autogov-releases-card` and `packages/backstage-plugin-autogov-status-catalog-column

## Changes Made

Add material dependancies into package.json for appropriate package locations.

---

## Checklist

- [x] Code formatted with `prettier`
- [x] Linting completed successfully
- [x] Tests added or updated
- [x] All tests run successfully
- [x] Documentation updated (if needed)

---

## Additional Notes